### PR TITLE
Several bug fixes.

### DIFF
--- a/src/Forms/DependentRequiredFields.php
+++ b/src/Forms/DependentRequiredFields.php
@@ -73,10 +73,10 @@ class DependentRequiredFields extends RequiredFields
         $fields = $this->form->Fields();
 
         foreach ($this->dependentRequired as $fieldName => $filter) {
-            $isRequired = false;
+            $isRequired = true;
             foreach ($filter as $filterKey => $filterData) {
-                // Field is already required, no need to re-process.
-                if ($isRequired) {
+                // Field is already not required, no need to re-process.
+                if (!$isRequired) {
                     break;
                 }
                 $dependencyFieldName = explode(':', $filterKey)[0];
@@ -85,27 +85,30 @@ class DependentRequiredFields extends RequiredFields
                 $tempObj->$dependencyFieldName = $dependencyValue;
                 $filterList = SearchFilterableArrayList::create([$tempObj]);
                 $isRequired = $filterList->filter($filterKey, $filterData)->count() !== 0;
-
-                // Field is required but has no value
-                if ($isRequired && empty($data[$fieldName])) {
-                    $formField = $fields->dataFieldByName($fieldName);
-                    $title = ($formField && !empty($formField->Title())) ? $formField->Title() : $fieldName;
-                    $errorMessage = _t(
-                        'SilverStripe\\Forms\\Form.FIELDISREQUIRED',
-                        '{name} is required',
-                        [
-                            'name' => strip_tags(
-                                '"' . $title . '"'
-                            )
-                        ]
-                    );
-                    $this->validationError(
-                        $fieldName,
-                        $errorMessage,
-                        "required"
-                    );
-                    $valid = false;
+                if ($fieldName != 'AdditionalAttendants') {
+//                     var_dump([$isRequired, $tempObj, $filterData, $filterKey]);die();
                 }
+            }
+
+            // Field is required but has no value
+            if ($isRequired && empty($data[$fieldName])) {
+                $formField = $fields->dataFieldByName($fieldName);
+                $title = ($formField && !empty($formField->Title())) ? $formField->Title() : $fieldName;
+                $errorMessage = _t(
+                    'SilverStripe\\Forms\\Form.FIELDISREQUIRED',
+                    '{name} is required',
+                    [
+                        'name' => strip_tags(
+                            '"' . $title . '"'
+                            )
+                    ]
+                    );
+                $this->validationError(
+                    $fieldName,
+                    $errorMessage,
+                    "required"
+                    );
+                $valid = false;
             }
         }
 

--- a/src/Forms/DependentRequiredFields.php
+++ b/src/Forms/DependentRequiredFields.php
@@ -100,14 +100,14 @@ class DependentRequiredFields extends RequiredFields
                     [
                         'name' => strip_tags(
                             '"' . $title . '"'
-                            )
+                        )
                     ]
-                    );
+                );
                 $this->validationError(
                     $fieldName,
                     $errorMessage,
                     "required"
-                    );
+                );
                 $valid = false;
             }
         }

--- a/src/ORM/LinqDataQuery.php
+++ b/src/ORM/LinqDataQuery.php
@@ -208,7 +208,11 @@ class LinqDataQuery extends DataQuery
                         }
                     }
                     for ($index = $i; $index <= $i + $numAdditional; $index++) {
-                        $whereAny[] = $this->prepareWhereClosure($matches['field'][$index], $matches['operator'][$index], $value[$index]);
+                        $whereAny[] = $this->prepareWhereClosure(
+                            $matches['field'][$index],
+                            $matches['operator'][$index],
+                            $value[$index]
+                        );
                     }
                     // Create a LINQ closure which returns true if any of the closures in $whereAny return true.
                     $this->where[] = $this->wrapClosures($whereAny);
@@ -272,7 +276,7 @@ class LinqDataQuery extends DataQuery
             if ($placeholder === 'NULL') {
                 // Insert null at the $ith index.
                 array_splice($value, $i, 0, [null]);
-            } else if ($numValues > 1) {
+            } elseif ($numValues > 1) {
                 // Combine values into one index of the array.
                 $value[$count] = array_slice($value, $count, $numValues);
                 // Unset values which are now part of the current $i index of $value

--- a/src/ORM/LinqDataQuery.php
+++ b/src/ORM/LinqDataQuery.php
@@ -43,7 +43,7 @@ class LinqDataQuery extends DataQuery
      * @var string
      */
     protected $whereRegex = '/(MATCH \()?"(?<field>[a-zA-Z0-9_-]+?)"(?(1)\)|) '
-    . '(?<operator>[a-zA-Z<>!= ]*?) (?<placeholder>\(?(\?|\?, ?|NULL)+\)?)'
+    . '(?<operator>[a-zA-Z<>!= ]*?) (?<placeholder>\(?([\?, ]|NULL)+\)?)'
     . ' ?(?<connection>OR|AND)?/';
 
     /**

--- a/src/ORM/LinqDataQuery.php
+++ b/src/ORM/LinqDataQuery.php
@@ -8,6 +8,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use YaLinqo\Enumerable;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\DataQueryManipulator;
+use App\Util\SignifyArrayLib;
 
 /**
  * An object representing a query of data from a given source.
@@ -42,7 +43,8 @@ class LinqDataQuery extends DataQuery
      * @var string
      */
     protected $whereRegex = '/(MATCH \()?"(?<field>[a-zA-Z0-9_-]+?)"(?(1)\)|) '
-    . '(?<operator>[a-zA-Z<>!= ]*?) (?<placeholder>\(?[?, ]+\)?)/';
+    . '(?<operator>[a-zA-Z<>!= ]*?) (?<placeholder>\(?(\?|\?, ?|NULL)+\)?)'
+    . ' ?(?<connection>OR|AND)?/';
 
     /**
      * An array of closure templates for where statements.
@@ -193,11 +195,32 @@ class LinqDataQuery extends DataQuery
                 continue;
             }
             for ($i = 0; $i < count($matches[0]); $i++) {
-                $this->where[] = $this->prepareWhereClosure(
-                    $matches['field'][$i],
-                    $matches['operator'][$i],
-                    $value[$i]
-                );
+                // 'OR' queries should be treated as a whereAny query.
+                if ($matches['connection'][$i] === 'OR' && isset($matches[$i + 1])) {
+                    $numAdditional = 1;
+                    $whereAny = array();
+                    $j = $i + 1;
+                    while ($j < count($matches[0])) {
+                        if ($matches['connection'][$j] === 'OR') {
+                            $numAdditional++;
+                        } else {
+                            break;
+                        }
+                    }
+                    for ($index = $i; $index <= $i + $numAdditional; $index++) {
+                        $whereAny[] = $this->prepareWhereClosure($matches['field'][$index], $matches['operator'][$index], $value[$index]);
+                    }
+                    // Create a LINQ closure which returns true if any of the closures in $whereAny return true.
+                    $this->where[] = $this->wrapClosures($whereAny);
+                    $i += $numAdditional;
+                } else {
+                    // Add the independent where closure.
+                    $this->where[] = $this->prepareWhereClosure(
+                        $matches['field'][$i],
+                        $matches['operator'][$i],
+                        $value[$i]
+                    );
+                }
             }
         }
         return $this;
@@ -243,10 +266,13 @@ class LinqDataQuery extends DataQuery
         }
         preg_match_all($this->whereRegex, $key, $matches);
         $count = 0;
-        foreach ($matches['placeholder'] as $placeholder) {
+        foreach ($matches['placeholder'] as $i => $placeholder) {
             // Check for values that are actually meant to be an array of values.
             $numValues = substr_count($placeholder, '?');
-            if ($numValues > 1) {
+            if ($placeholder === 'NULL') {
+                // Insert null at the $ith index.
+                array_splice($value, $i, 0, [null]);
+            } else if ($numValues > 1) {
                 // Combine values into one index of the array.
                 $value[$count] = array_slice($value, $count, $numValues);
                 // Unset values which are now part of the current $i index of $value

--- a/tests/SearchFilterableArrayListTest.php
+++ b/tests/SearchFilterableArrayListTest.php
@@ -234,7 +234,7 @@ class SearchFilterableArrayListTest extends SapphireTest
         self::assertCount(1, $notExclude1Retained, 'One object remains in the list.');
         self::assertContains('First Object', $notExclude1Retained);
 
-        // Exclude using the "not" modifier which returns an empty list.
+        // Exclude using the "not" modifier which returns two items.
         $notExclude2 = $list->exclude([
             'Title:not' => 'First Object',
             'Title:ExactMatch:not' => 'Second Object',

--- a/tests/SearchFilterableArrayListTest.php
+++ b/tests/SearchFilterableArrayListTest.php
@@ -80,7 +80,7 @@ class SearchFilterableArrayListTest extends SapphireTest
     public function testFilter()
     {
         $list = new SearchFilterableArrayList($this->objects);
-
+        
         // Filter using the "not" modifier which retains 3 objects.
         $notFilter1 = $list->filter('Title:not', 'First Object');
         $notFilter1Retained = $notFilter1->column('Title');
@@ -100,7 +100,7 @@ class SearchFilterableArrayListTest extends SapphireTest
         // Filter using the "not" modifier which retains 4 objects.
         $notFilter3 = $list->filter('Title:not', 'No Object');
         self::assertCount(4, $notFilter3->toArray(), 'All objects are retained.');
-
+        
         // Filter to test multiple value arguments which retains two objects.
         $basicFilter1 = $list->filter('Title', ['First Object', 'Second Object']);
         $basicFilter1Retained = $basicFilter1->column('Title');
@@ -114,7 +114,7 @@ class SearchFilterableArrayListTest extends SapphireTest
         ]);
         self::assertEmpty($basicFilter2->toArray(), 'All objects are filtered out.');
     }
-
+    
     /**
      * @useDatabase false
      */
@@ -184,14 +184,14 @@ class SearchFilterableArrayListTest extends SapphireTest
         ]);
         self::assertEmpty($greaterLesserFilter5->toArray(), 'All objects are filtered out.');
     }
-    
+
     /**
      * @useDatabase false
      */
     public function testFilterMultipleRequirements()
     {
         $list = new SearchFilterableArrayList($this->objects);
-        
+
         // Filter testing multiple filter items which retains 1 object.
         $multiFilter1 = $list->filter([
           'NoCase:nocase' => 'CASE SENSITIVE',
@@ -200,7 +200,7 @@ class SearchFilterableArrayListTest extends SapphireTest
         $multiFilter1Retained = $multiFilter1->column('Title');
         self::assertCount(1, $multiFilter1Retained, 'One object remains in the list.');
         self::assertContains('Second Object', $multiFilter1Retained);
-        
+
         // Filter testing multiple filter items which retains 0 objects.
         $multiFilter2 = $list->filter([
           'NoCase:case' => 'CASE SENSITIVE',

--- a/tests/SearchFilterableArrayListTest.php
+++ b/tests/SearchFilterableArrayListTest.php
@@ -115,6 +115,9 @@ class SearchFilterableArrayListTest extends SapphireTest
         self::assertEmpty($basicFilter2->toArray(), 'All objects are filtered out.');
     }
 
+    /**
+     * @useDatabase false
+     */
     public function testFilterAdvanced()
     {
         $list = new SearchFilterableArrayList($this->objects);

--- a/tests/SearchFilterableArrayListTest.php
+++ b/tests/SearchFilterableArrayListTest.php
@@ -184,6 +184,30 @@ class SearchFilterableArrayListTest extends SapphireTest
         ]);
         self::assertEmpty($greaterLesserFilter5->toArray(), 'All objects are filtered out.');
     }
+    
+    /**
+     * @useDatabase false
+     */
+    public function testFilterMultipleRequirements()
+    {
+        $list = new SearchFilterableArrayList($this->objects);
+        
+        // Filter testing multiple filter items which retains 1 object.
+        $multiFilter1 = $list->filter([
+          'NoCase:nocase' => 'CASE SENSITIVE',
+          'StartsWithTest:StartsWith' => 'Not',
+        ]);
+        $multiFilter1Retained = $multiFilter1->column('Title');
+        self::assertCount(1, $multiFilter1Retained, 'One object remains in the list.');
+        self::assertContains('Second Object', $multiFilter1Retained);
+        
+        // Filter testing multiple filter items which retains 0 objects.
+        $multiFilter2 = $list->filter([
+          'NoCase:case' => 'CASE SENSITIVE',
+          'StartsWithTest:StartsWith' => 'Not',
+        ]);
+        self::assertEmpty($multiFilter2->toArray(), 'All objects are excluded.');
+    }
 
     /**
      * @useDatabase false


### PR DESCRIPTION
- Accept NULL values. Previously these could only be inferred and would sometimes be in the wrong place.
- Correctly process OR queries. Previously a statement such as `"Field1" != ? OR "Field2" IS NULL` would be incorrectly treated as an AND.
- Treat multiple filter values as AND. `ArrayList::filter(['Field1' => 'value1', 'Field2' => 'value2'])` requires both of the key value pairs to match an item in the list. SearchFilterableArrayList should behave the same.